### PR TITLE
fix(s3): fix s3 endpoint and url parsing

### DIFF
--- a/internal/pkg/aws/s3/s3.go
+++ b/internal/pkg/aws/s3/s3.go
@@ -7,6 +7,7 @@ package s3
 import (
 	"fmt"
 	"io"
+	"regexp"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -230,7 +231,11 @@ func parseS3URI(uri string) (bucket, key string, err error) {
 //
 // [virtual-hosted-style access URL]: https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-bucket-intro.html#virtual-host-style-url-ex
 func parseObjectURL(url string) (bucket, key string, err error) {
-	parsedURL := strings.SplitN(strings.TrimPrefix(url, "https://"), "/", 2)
+	httpTrimRegex := regexp.MustCompile(`^https?://`) // handle http+https case
+
+	trimmedURL := httpTrimRegex.ReplaceAllString(url, "")
+	parsedURL := strings.SplitN(trimmedURL, "/", 2)
+
 	if len(parsedURL) != 2 {
 		return "", "", fmt.Errorf("cannot parse S3 URL %s into bucket name and key", url)
 	}

--- a/internal/pkg/endpoints/localstack.go
+++ b/internal/pkg/endpoints/localstack.go
@@ -10,11 +10,15 @@ type localStackResolver struct {
 	defaultResolver endpoints.Resolver
 }
 
-func getLocalStackUrl() string {
+func getLocalStackUrl(service string) string {
 	hostname := os.Getenv("LOCALSTACK_HOSTNAME")
 
 	if hostname == "" {
 		hostname = "localhost.localstack.cloud"
+	}
+
+	if service == "s3" {
+		hostname = "s3.localhost.localstack.cloud"
 	}
 
 	port := os.Getenv("EDGE_PORT")
@@ -28,7 +32,7 @@ func getLocalStackUrl() string {
 		disableSSL = false
 	}
 
-	return endpoints.AddScheme(hostname + ":" + port, disableSSL)
+	return endpoints.AddScheme(hostname+":"+port, disableSSL)
 }
 
 func (l *localStackResolver) EndpointFor(service, region string, opts ...func(*endpoints.Options)) (endpoints.ResolvedEndpoint, error) {
@@ -38,7 +42,7 @@ func (l *localStackResolver) EndpointFor(service, region string, opts ...func(*e
 		return endpointFor, err
 	}
 
-	endpointFor.URL = getLocalStackUrl()
+	endpointFor.URL = getLocalStackUrl(service)
 
 	return endpointFor, err
 }


### PR DESCRIPTION
## Summary

* fix s3 endpoint resolution
* add support for http to the s3 url parser, otherwise s3 resources remain undiscoverable

## Testing

```bash
make compile-<your-version>
make package-custom-resources

awslocal route53 create-hosted-zone --caller-reference example.com --name example.com
/<path to binary>/<binary-name> app init --domain example.com hosted
/<path to binary>/<binary-name> env init -n dev
/<path to binary>/<binary-name> env deploy -n dev
``` 

## Linked issues

* https://localstack-community.slack.com/archives/C0553QWK55M

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
